### PR TITLE
chore: bump i18n deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "vitest": "^3.0.5"
   },
   "resolutions": {
-    "@storybook/react-vite@npm:8.5.3/@joshwooding/vite-plugin-react-docgen-typescript": "0.5.0"
+    "@storybook/react-vite@npm:8.6.0-alpha.4/@joshwooding/vite-plugin-react-docgen-typescript": "0.5.0"
   },
   "importSort": {
     ".js, .jsx, .ts, .tsx": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -42,7 +42,7 @@
     "duration-relativetimeformat": "^2.0.4",
     "i18next": "^21.8.8",
     "i18next-browser-languagedetector": "^6.1.4",
-    "pretty-bytes": "^5.6.0"
+    "pretty-bytes": "^6.1.1"
   },
   "devDependencies": {
     "@cpro-js/react-app-state": "0.3.0",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -37,11 +37,11 @@
   },
   "dependencies": {
     "@date-fns/tz": "^1.2.0",
+    "@formatjs/fast-memoize": "^2.2.6",
     "date-fns": "^4.1.0",
     "duration-relativetimeformat": "^2.0.4",
     "i18next": "^21.8.8",
     "i18next-browser-languagedetector": "^6.1.4",
-    "intl-format-cache": "^4.3.1",
     "pretty-bytes": "^5.6.0"
   },
   "devDependencies": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -36,9 +36,9 @@
     }
   },
   "dependencies": {
-    "date-fns": "2.16.1",
-    "date-fns-tz": "^1.1.6",
-    "duration-relativetimeformat": "2.0.4",
+    "@date-fns/tz": "^1.2.0",
+    "date-fns": "^4.1.0",
+    "duration-relativetimeformat": "^2.0.4",
     "i18next": "^21.8.8",
     "i18next-browser-languagedetector": "^6.1.4",
     "intl-format-cache": "^4.3.1",

--- a/packages/i18n/src/i18n/date/DateServiceImpl.ts
+++ b/packages/i18n/src/i18n/date/DateServiceImpl.ts
@@ -1,7 +1,6 @@
 import { service } from "@cpro-js/react-di";
+import { TZDate, tz } from "@date-fns/tz";
 import { lightFormat, parse } from "date-fns";
-import getTimezoneOffset from "date-fns-tz/getTimezoneOffset/index.js"; // cjs module
-import utcToZonedTime from "date-fns-tz/utcToZonedTime/index.js"; // cjs module
 import Duration from "duration-relativetimeformat";
 import memoizeFormatConstructor from "intl-format-cache";
 
@@ -25,10 +24,7 @@ export class DateServiceImpl extends DateService {
     options: TimezoneOptions
   ): string {
     const formatStringFixed = DateServiceImpl.replaceBrackets(formatString);
-    const transformedDate = this.applyTimeZoneToLocalDate(
-      date,
-      options.timezone
-    );
+    const transformedDate = new TZDate(date, options.timezone);
 
     return lightFormat(transformedDate, formatStringFixed);
   }
@@ -37,27 +33,18 @@ export class DateServiceImpl extends DateService {
     date: Date,
     options: LocaleOptions & TimezoneOptions & DateFormatOptions
   ): string {
-    const transformedDate = this.applyTimeZoneToLocalDate(
-      date,
-      options.timezone
-    );
-
     return getDateTimeFormat(options.locale, {
       year: options.year,
       month: options.month,
       day: options.day,
-    }).format(transformedDate);
+      timeZone: options.timezone,
+    }).format(date);
   }
 
   formatDateTime(
     date: Date,
     options: LocaleOptions & TimezoneOptions & DateTimeFormatOptions
   ): string {
-    const transformedDate = this.applyTimeZoneToLocalDate(
-      date,
-      options.timezone
-    );
-
     return getDateTimeFormat(options.locale, {
       year: options.year,
       month: options.month,
@@ -65,23 +52,20 @@ export class DateServiceImpl extends DateService {
       hour: options.hour,
       minute: options.minute,
       second: options.second,
-    }).format(transformedDate);
+      timeZone: options.timezone,
+    }).format(date);
   }
 
   formatTime(
     date: Date,
     options: LocaleOptions & TimezoneOptions & TimeFormatOptions
   ): string {
-    const transformedDate = this.applyTimeZoneToLocalDate(
-      date,
-      options.timezone
-    );
-
     return getDateTimeFormat(options.locale, {
       hour: options.hour,
       minute: options.minute,
       second: options.second,
-    }).format(transformedDate);
+      timeZone: options.timezone,
+    }).format(date);
   }
 
   formatRelative(date: Date, options: LocaleOptions): string {
@@ -99,21 +83,12 @@ export class DateServiceImpl extends DateService {
     options: TimezoneOptions
   ): Date {
     const formatStringFixed = DateServiceImpl.replaceBrackets(formatString);
-    const parsedDateLocal = parse(dateString, formatStringFixed, new Date());
+    const parsedDateInTz = parse(dateString, formatStringFixed, new Date(), {
+      in: tz(options.timezone),
+    });
 
-    // date is in local time, positive offset means that local timezone is behind UTC and negative if it is ahead
-    const offset = parsedDateLocal.getTimezoneOffset() * 60 * 1000;
-    const normalizedUtcDate = new Date(parsedDateLocal.getTime() - offset);
-
-    return new Date(
-      normalizedUtcDate.getTime() -
-        getTimezoneOffset(options.timezone, normalizedUtcDate)
-    );
-  }
-
-  applyTimeZoneToLocalDate(date: Date, timezone: string) {
-    // shift locale javascript date to zoned time date
-    return utcToZonedTime(date, timezone);
+    // transform to system date
+    return new Date(parsedDateInTz);
   }
 
   private static replaceBrackets(formatString: string): string {

--- a/packages/i18n/src/i18n/date/DateServiceImpl.ts
+++ b/packages/i18n/src/i18n/date/DateServiceImpl.ts
@@ -1,8 +1,8 @@
 import { service } from "@cpro-js/react-di";
 import { TZDate, tz } from "@date-fns/tz";
+import { memoize } from "@formatjs/fast-memoize";
 import { lightFormat, parse } from "date-fns";
 import Duration from "duration-relativetimeformat";
-import memoizeFormatConstructor from "intl-format-cache";
 
 import {
   DateFormatOptions,
@@ -13,8 +13,18 @@ import {
   TimezoneOptions,
 } from "./DateService";
 
-const getDateTimeFormat = memoizeFormatConstructor(Intl.DateTimeFormat);
-const getRelativeTimeFormat = memoizeFormatConstructor(Duration);
+type IntlDateTimeFormatOptions = ConstructorParameters<
+  typeof Intl.DateTimeFormat
+>[1];
+const getDateTimeFormat = memoize(
+  (locale: string, options: IntlDateTimeFormatOptions) =>
+    new Intl.DateTimeFormat(locale, options)
+);
+
+type DurationOptions = ConstructorParameters<typeof Duration>[1];
+const getRelativeTimeFormat = memoize(
+  (locale: string, options: DurationOptions) => new Duration(locale, options)
+);
 
 @service()
 export class DateServiceImpl extends DateService {

--- a/packages/i18n/src/i18n/number/NumberServiceImpl.ts
+++ b/packages/i18n/src/i18n/number/NumberServiceImpl.ts
@@ -1,9 +1,15 @@
-import memoizeFormatConstructor from "intl-format-cache";
+import { memoize } from "@formatjs/fast-memoize";
 import prettyBytes from "pretty-bytes";
 
 import { NumberService } from "./NumberService";
 
-const getNumberFormat = memoizeFormatConstructor(Intl.NumberFormat);
+type IntlNumberFormatOptions = ConstructorParameters<
+  typeof Intl.NumberFormat
+>[1];
+const getNumberFormat = memoize(
+  (locale: string, options: IntlNumberFormatOptions) =>
+    new Intl.NumberFormat(locale, options)
+);
 
 const countDecimals = (value: number) => {
   if (Math.floor(value) !== value)

--- a/packages/i18n/vite.config.ts
+++ b/packages/i18n/vite.config.ts
@@ -1,11 +1,8 @@
-import {
-  createLibraryViteConfig
-} from "@cpro-js/tooling/vite";
+import { createLibraryViteConfig } from "@cpro-js/tooling/vite";
 import { defineConfig, mergeConfig } from "vitest/config";
 
-
 export default defineConfig(() => {
-  return mergeConfig(createLibraryViteConfig(__dirname, { bundleModules: ["intl-format-cache"] }), {
+  return mergeConfig(createLibraryViteConfig(__dirname, {}), {
     test: {
       setupFiles: ["./vitest.setupFile.ts"],
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -554,7 +554,7 @@ __metadata:
     duration-relativetimeformat: "npm:^2.0.4"
     i18next: "npm:^21.8.8"
     i18next-browser-languagedetector: "npm:^6.1.4"
-    pretty-bytes: "npm:^5.6.0"
+    pretty-bytes: "npm:^6.1.1"
     react: "npm:^19.0.0"
     reflect-metadata: "npm:^0.2.2"
     typescript: "npm:^5.7.3"
@@ -4457,10 +4457,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-bytes@npm:^5.6.0":
-  version: 5.6.0
-  resolution: "pretty-bytes@npm:5.6.0"
-  checksum: 10c0/f69f494dcc1adda98dbe0e4a36d301e8be8ff99bfde7a637b2ee2820e7cb583b0fc0f3a63b0e3752c01501185a5cf38602c7be60da41bdf84ef5b70e89c370f3
+"pretty-bytes@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "pretty-bytes@npm:6.1.1"
+  checksum: 10c0/c7a660b933355f3b4587ad3f001c266a8dd6afd17db9f89ebc50812354bb142df4b9600396ba5999bdb1f9717300387dc311df91895c5f0f2a1780e22495b5f8
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -547,13 +547,13 @@ __metadata:
     "@cpro-js/react-di": "npm:0.3.0"
     "@cpro-js/tooling": "npm:*"
     "@date-fns/tz": "npm:^1.2.0"
+    "@formatjs/fast-memoize": "npm:^2.2.6"
     "@types/node": "npm:^20.17.16"
     "@types/react": "npm:^19.0.8"
     date-fns: "npm:^4.1.0"
     duration-relativetimeformat: "npm:^2.0.4"
     i18next: "npm:^21.8.8"
     i18next-browser-languagedetector: "npm:^6.1.4"
-    intl-format-cache: "npm:^4.3.1"
     pretty-bytes: "npm:^5.6.0"
     react: "npm:^19.0.0"
     reflect-metadata: "npm:^0.2.2"
@@ -790,6 +790,15 @@ __metadata:
   version: 0.24.2
   resolution: "@esbuild/win32-x64@npm:0.24.2"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@formatjs/fast-memoize@npm:^2.2.6":
+  version: 2.2.6
+  resolution: "@formatjs/fast-memoize@npm:2.2.6"
+  dependencies:
+    tslib: "npm:2"
+  checksum: 10c0/dccdc21105af673e58ec7b04eb17cd6fde1fb1a7e7a446273ca43f7ab97c26d5c0fcc2b9e80d5b54bf9b80354f9e1e681273c0ed26633ec72f0adc2d116dfd7f
   languageName: node
   linkType: hard
 
@@ -3536,13 +3545,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"intl-format-cache@npm:^4.3.1":
-  version: 4.3.1
-  resolution: "intl-format-cache@npm:4.3.1"
-  checksum: 10c0/791b285630fbc0b41fb8251fc8a3baf4bb0d1e9cd9bbe0a93f9166f15adcd969b6319f57893e325a3214ec0db5e596f398b0efc8bdfac8495022cf50d55aa23f
-  languageName: node
-  linkType: hard
-
 "inversify-react@npm:^1.2.0":
   version: 1.2.0
   resolution: "inversify-react@npm:1.2.0"
@@ -5307,7 +5309,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.1":
+"tslib@npm:2, tslib@npm:^2.0.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62

--- a/yarn.lock
+++ b/yarn.lock
@@ -828,10 +828,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@joshwooding/vite-plugin-react-docgen-typescript@npm:0.4.2":
-  version: 0.4.2
-  resolution: "@joshwooding/vite-plugin-react-docgen-typescript@npm:0.4.2"
+"@isaacs/cliui@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "@isaacs/cliui@npm:8.0.2"
   dependencies:
+    string-width: "npm:^5.1.2"
+    string-width-cjs: "npm:string-width@^4.2.0"
+    strip-ansi: "npm:^7.0.1"
+    strip-ansi-cjs: "npm:strip-ansi@^6.0.1"
+    wrap-ansi: "npm:^8.1.0"
+    wrap-ansi-cjs: "npm:wrap-ansi@^7.0.0"
+  checksum: 10c0/b1bf42535d49f11dc137f18d5e4e63a28c5569de438a221c369483731e9dac9fb797af554e8bf02b6192d1e5eba6e6402cf93900c3d0ac86391d00d04876789e
+  languageName: node
+  linkType: hard
+
+"@joshwooding/vite-plugin-react-docgen-typescript@npm:0.5.0":
+  version: 0.5.0
+  resolution: "@joshwooding/vite-plugin-react-docgen-typescript@npm:0.5.0"
+  dependencies:
+    glob: "npm:^10.0.0"
     magic-string: "npm:^0.27.0"
     react-docgen-typescript: "npm:^2.2.2"
   peerDependencies:
@@ -840,7 +855,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/355d13ad92a9da786b561a25250e6c94a8e51d235ced345e54ebfe709abc45ab60c2a8d06599df6ec0441fba01720f189883429943cb62dff9a4c31b59f0939c
+  checksum: 10c0/dd5bcd01c685c67bcfb4676639f15319937867ad5af0dc083991fe9ae9e66302c72fec53d12e0616a45eadb0ae715bea144d0302f408a44f1eeab14c5160ad4a
   languageName: node
   linkType: hard
 
@@ -958,6 +973,13 @@ __metadata:
     mkdirp: "npm:^1.0.4"
     rimraf: "npm:^3.0.2"
   checksum: 10c0/02e946f3dafcc6743132fe2e0e2b585a96ca7265653a38df5a3e53fcf26c7c7a57fc0f861d7c689a23fdb6d6836c7eea5050c8086abf3c994feb2208d1514ff0
+  languageName: node
+  linkType: hard
+
+"@pkgjs/parseargs@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@pkgjs/parseargs@npm:0.11.0"
+  checksum: 10c0/5bd7576bb1b38a47a7fc7b51ac9f38748e772beebc56200450c4a817d712232b8f1d3ef70532c80840243c657d491cf6a6be1e3a214cff907645819fdc34aadd
   languageName: node
   linkType: hard
 
@@ -2251,6 +2273,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^6.0.1":
+  version: 6.1.0
+  resolution: "ansi-regex@npm:6.1.0"
+  checksum: 10c0/a91daeddd54746338478eef88af3439a7edf30f8e23196e2d6ed182da9add559c601266dbef01c2efa46a958ad6f1f8b176799657616c702b5b02e799e7fd8dc
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
@@ -2260,7 +2289,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^4.1.0":
+"ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
   dependencies:
@@ -2273,6 +2302,13 @@ __metadata:
   version: 5.2.0
   resolution: "ansi-styles@npm:5.2.0"
   checksum: 10c0/9c4ca80eb3c2fb7b33841c210d2f20807f40865d27008d7c3f707b7f95cab7d67462a565e2388ac3285b71cb3d9bb2173de8da37c57692a362885ec34d6e27df
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^6.1.0":
+  version: 6.2.1
+  resolution: "ansi-styles@npm:6.2.1"
+  checksum: 10c0/5d1ec38c123984bcedd996eac680d548f31828bd679a66db2bdf11844634dde55fec3efa9c6bb1d89056a5e79c1ac540c4c784d592ea1d25028a92227d2f2d5c
   languageName: node
   linkType: hard
 
@@ -2681,6 +2717,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-spawn@npm:^7.0.0":
+  version: 7.0.6
+  resolution: "cross-spawn@npm:7.0.6"
+  dependencies:
+    path-key: "npm:^3.1.0"
+    shebang-command: "npm:^2.0.0"
+    which: "npm:^2.0.1"
+  checksum: 10c0/053ea8b2135caff68a9e81470e845613e374e7309a47731e81639de3eaeb90c3d01af0e0b44d2ab9d50b43467223b88567dfeb3262db942dc063b9976718ffc1
+  languageName: node
+  linkType: hard
+
 "csstype@npm:^3.0.2":
   version: 3.0.8
   resolution: "csstype@npm:3.0.8"
@@ -2813,6 +2860,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eastasianwidth@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "eastasianwidth@npm:0.2.0"
+  checksum: 10c0/26f364ebcdb6395f95124fda411f63137a4bfb5d3a06453f7f23dfe52502905bd84e0488172e0f9ec295fdc45f05c23d5d91baf16bd26f0fe9acd777a188dc39
+  languageName: node
+  linkType: hard
+
 "electron-to-chromium@npm:^1.3.811":
   version: 1.3.818
   resolution: "electron-to-chromium@npm:1.3.818"
@@ -2824,6 +2878,20 @@ __metadata:
   version: 1.5.90
   resolution: "electron-to-chromium@npm:1.5.90"
   checksum: 10c0/864715adfebb5932a78f776c99f28a50942884302b42ee6de0ab64ca135891a5a43af3a7c719a7335687c0ee201561011e37d4994558a795f67b9e44f20fc6ee
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "emoji-regex@npm:8.0.0"
+  checksum: 10c0/b6053ad39951c4cf338f9092d7bfba448cdfd46fe6a2a034700b149ac9ffbc137e361cbd3c442297f86bed2e5f7576c1b54cc0a6bf8ef5106cc62f496af35010
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^9.2.2":
+  version: 9.2.2
+  resolution: "emoji-regex@npm:9.2.2"
+  checksum: 10c0/af014e759a72064cf66e6e694a7fc6b0ed3d8db680427b021a89727689671cefe9d04151b2cad51dbaf85d5ba790d061cd167f1cf32eb7b281f6368b3c181639
   languageName: node
   linkType: hard
 
@@ -3101,6 +3169,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"foreground-child@npm:^3.1.0":
+  version: 3.3.0
+  resolution: "foreground-child@npm:3.3.0"
+  dependencies:
+    cross-spawn: "npm:^7.0.0"
+    signal-exit: "npm:^4.0.1"
+  checksum: 10c0/028f1d41000553fcfa6c4bb5c372963bf3d9bf0b1f25a87d1a6253014343fb69dfb1b42d9625d7cf44c8ba429940f3d0ff718b62105d4d4a4f6ef8ca0a53faa2
+  languageName: node
+  linkType: hard
+
 "fs-extra@npm:~11.3.0":
   version: 11.3.0
   resolution: "fs-extra@npm:11.3.0"
@@ -3237,6 +3315,22 @@ __metadata:
   dependencies:
     resolve-pkg-maps: "npm:^1.0.0"
   checksum: 10c0/c9b5572c5118923c491c04285c73bd55b19e214992af957c502a3be0fc0043bb421386ffd45ca3433c0a7fba81221ca300479e8393960acf15d0ed4563f38a86
+  languageName: node
+  linkType: hard
+
+"glob@npm:^10.0.0":
+  version: 10.4.5
+  resolution: "glob@npm:10.4.5"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^3.1.2"
+    minimatch: "npm:^9.0.4"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^1.11.1"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10c0/19a9759ea77b8e3ca0a43c2f07ecddc2ad46216b786bb8f993c445aee80d345925a21e5280c7b7c6c59e860a0154b84e4b2b60321fea92cd3c56b4a7489f160e
   languageName: node
   linkType: hard
 
@@ -3657,6 +3751,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-fullwidth-code-point@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-fullwidth-code-point@npm:3.0.0"
+  checksum: 10c0/bb11d825e049f38e04c06373a8d72782eee0205bda9d908cc550ccb3c59b99d750ff9537982e01733c1c94a58e35400661f57042158ff5e8f3e90cf936daf0fc
+  languageName: node
+  linkType: hard
+
 "is-generator-function@npm:^1.0.7":
   version: 1.1.0
   resolution: "is-generator-function@npm:1.1.0"
@@ -3717,6 +3818,19 @@ __metadata:
   version: 2.0.0
   resolution: "isexe@npm:2.0.0"
   checksum: 10c0/228cfa503fadc2c31596ab06ed6aa82c9976eec2bfd83397e7eaf06d0ccf42cd1dfd6743bf9aeb01aebd4156d009994c5f76ea898d2832c1fe342da923ca457d
+  languageName: node
+  linkType: hard
+
+"jackspeak@npm:^3.1.2":
+  version: 3.4.3
+  resolution: "jackspeak@npm:3.4.3"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+    "@pkgjs/parseargs": "npm:^0.11.0"
+  dependenciesMeta:
+    "@pkgjs/parseargs":
+      optional: true
+  checksum: 10c0/6acc10d139eaefdbe04d2f679e6191b3abf073f111edf10b1de5302c97ec93fffeb2fdd8681ed17f16268aa9dd4f8c588ed9d1d3bffbbfa6e8bf897cbb3149b9
   languageName: node
   linkType: hard
 
@@ -3876,6 +3990,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^10.2.0":
+  version: 10.4.3
+  resolution: "lru-cache@npm:10.4.3"
+  checksum: 10c0/ebd04fbca961e6c1d6c0af3799adcc966a1babe798f685bb84e6599266599cd95d94630b10262f5424539bc4640107e8a33aa28585374abf561d30d16f4b39fb
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
@@ -3990,7 +4111,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.3":
+"minimatch@npm:^9.0.3, minimatch@npm:^9.0.4":
   version: 9.0.5
   resolution: "minimatch@npm:9.0.5"
   dependencies:
@@ -4079,6 +4200,13 @@ __metadata:
   dependencies:
     yallist: "npm:^4.0.0"
   checksum: 10c0/5dbbf1afd68aa686f0b587f2104c96c22b517da2db35787329ff460128efe583ba363e9cd4572895cdf0f0633fa3ad1b65283a953d889a76f11bdfbb19567bc6
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "minipass@npm:7.1.2"
+  checksum: 10c0/b0fd20bb9fb56e5fa9a8bfac539e8915ae07430a619e4b86ff71f5fc757ef3924b23b2c4230393af1eda647ed3d75739e4e0acb250a6b1eb277cf7f8fe449557
   languageName: node
   linkType: hard
 
@@ -4321,6 +4449,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"package-json-from-dist@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "package-json-from-dist@npm:1.0.1"
+  checksum: 10c0/62ba2785eb655fec084a257af34dbe24292ab74516d6aecef97ef72d4897310bc6898f6c85b5cd22770eaa1ce60d55a0230e150fb6a966e3ecd6c511e23d164b
+  languageName: node
+  linkType: hard
+
 "parse-json@npm:^4.0.0":
   version: 4.0.0
   resolution: "parse-json@npm:4.0.0"
@@ -4352,10 +4487,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-key@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "path-key@npm:3.1.1"
+  checksum: 10c0/748c43efd5a569c039d7a00a03b58eecd1d75f3999f5a28303d75f521288df4823bc057d8784eb72358b2895a05f29a070bc9f1f17d28226cc4e62494cc58c4c
+  languageName: node
+  linkType: hard
+
 "path-parse@npm:^1.0.6, path-parse@npm:^1.0.7":
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
   checksum: 10c0/11ce261f9d294cc7a58d6a574b7f1b935842355ec66fba3c3fd79e0f036462eaf07d0aa95bb74ff432f9afef97ce1926c720988c6a7451d8a584930ae7de86e1
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^1.11.1":
+  version: 1.11.1
+  resolution: "path-scurry@npm:1.11.1"
+  dependencies:
+    lru-cache: "npm:^10.2.0"
+    minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
+  checksum: 10c0/32a13711a2a505616ae1cc1b5076801e453e7aae6ac40ab55b388bb91b9d0547a52f5aaceff710ea400205f18691120d4431e520afbe4266b836fadede15872d
   languageName: node
   linkType: hard
 
@@ -4991,6 +5143,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"shebang-command@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "shebang-command@npm:2.0.0"
+  dependencies:
+    shebang-regex: "npm:^3.0.0"
+  checksum: 10c0/a41692e7d89a553ef21d324a5cceb5f686d1f3c040759c50aab69688634688c5c327f26f3ecf7001ebfd78c01f3c7c0a11a7c8bfd0a8bc9f6240d4f40b224e4e
+  languageName: node
+  linkType: hard
+
+"shebang-regex@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "shebang-regex@npm:3.0.0"
+  checksum: 10c0/1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
+  languageName: node
+  linkType: hard
+
 "siginfo@npm:^2.0.0":
   version: 2.0.0
   resolution: "siginfo@npm:2.0.0"
@@ -5002,6 +5170,13 @@ __metadata:
   version: 3.0.3
   resolution: "signal-exit@npm:3.0.3"
   checksum: 10c0/645cf460a417158e7d7fd03fb276aa12aecc49ab61a2ea36dac1987870a454e8af476ed926c8a8713a1adfde69c5964a4ca322c87fcca2367b36e1681207cf5f
+  languageName: node
+  linkType: hard
+
+"signal-exit@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "signal-exit@npm:4.1.0"
+  checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
   languageName: node
   linkType: hard
 
@@ -5109,6 +5284,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0":
+  version: 4.2.3
+  resolution: "string-width@npm:4.2.3"
+  dependencies:
+    emoji-regex: "npm:^8.0.0"
+    is-fullwidth-code-point: "npm:^3.0.0"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10c0/1e525e92e5eae0afd7454086eed9c818ee84374bb80328fc41217ae72ff5f065ef1c9d7f72da41de40c75fa8bb3dee63d92373fd492c84260a552c636392a47b
+  languageName: node
+  linkType: hard
+
 "string-width@npm:^1.0.1":
   version: 1.0.2
   resolution: "string-width@npm:1.0.2"
@@ -5130,12 +5316,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-width@npm:^5.0.1, string-width@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "string-width@npm:5.1.2"
+  dependencies:
+    eastasianwidth: "npm:^0.2.0"
+    emoji-regex: "npm:^9.2.2"
+    strip-ansi: "npm:^7.0.1"
+  checksum: 10c0/ab9c4264443d35b8b923cbdd513a089a60de339216d3b0ed3be3ba57d6880e1a192b70ae17225f764d7adbf5994e9bb8df253a944736c15a0240eff553c678ca
+  languageName: node
+  linkType: hard
+
 "string_decoder@npm:~1.1.1":
   version: 1.1.1
   resolution: "string_decoder@npm:1.1.1"
   dependencies:
     safe-buffer: "npm:~5.1.0"
   checksum: 10c0/b4f89f3a92fd101b5653ca3c99550e07bdf9e13b35037e9e2a1c7b47cec4e55e06ff3fc468e314a0b5e80bfbaf65c1ca5a84978764884ae9413bec1fc6ca924e
+  languageName: node
+  linkType: hard
+
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "strip-ansi@npm:6.0.1"
+  dependencies:
+    ansi-regex: "npm:^5.0.1"
+  checksum: 10c0/1ae5f212a126fe5b167707f716942490e3933085a5ff6c008ab97ab2f272c8025d3aa218b7bd6ab25729ca20cc81cddb252102f8751e13482a5199e873680952
   languageName: node
   linkType: hard
 
@@ -5154,6 +5360,15 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^3.0.0"
   checksum: 10c0/d75d9681e0637ea316ddbd7d4d3be010b1895a17e885155e0ed6a39755ae0fd7ef46e14b22162e66a62db122d3a98ab7917794e255532ab461bb0a04feb03e7d
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^7.0.1":
+  version: 7.1.0
+  resolution: "strip-ansi@npm:7.1.0"
+  dependencies:
+    ansi-regex: "npm:^6.0.1"
+  checksum: 10c0/a198c3762e8832505328cbf9e8c8381de14a4fa50a4f9b2160138158ea88c0f5549fb50cb13c651c3088f47e63a108b34622ec18c0499b6c8c3a5ddf6b305ac4
   languageName: node
   linkType: hard
 
@@ -5698,7 +5913,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^2.0.2":
+"which@npm:^2.0.1, which@npm:^2.0.2":
   version: 2.0.2
   resolution: "which@npm:2.0.2"
   dependencies:
@@ -5727,6 +5942,28 @@ __metadata:
   dependencies:
     string-width: "npm:^1.0.2 || 2"
   checksum: 10c0/9bf69ad55f7bcccd5a7af2ebbb8115aebf1b17e6d4f0a2a40a84f5676e099153b9adeab331e306661bf2a8419361bacba83057a62163947507473ce7ac4116b7
+  languageName: node
+  linkType: hard
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version: 7.0.0
+  resolution: "wrap-ansi@npm:7.0.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 10c0/d15fc12c11e4cbc4044a552129ebc75ee3f57aa9c1958373a4db0292d72282f54373b536103987a4a7594db1ef6a4f10acf92978f79b98c49306a4b58c77d4da
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "wrap-ansi@npm:8.1.0"
+  dependencies:
+    ansi-styles: "npm:^6.1.0"
+    string-width: "npm:^5.0.1"
+    strip-ansi: "npm:^7.0.1"
+  checksum: 10c0/138ff58a41d2f877eae87e3282c0630fc2789012fc1af4d6bd626eeb9a2f9a65ca92005e6e69a75c7b85a68479fe7443c7dbe1eb8fbaa681a4491364b7c55c60
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,11 +546,11 @@ __metadata:
     "@cpro-js/react-app-state": "npm:0.3.0"
     "@cpro-js/react-di": "npm:0.3.0"
     "@cpro-js/tooling": "npm:*"
+    "@date-fns/tz": "npm:^1.2.0"
     "@types/node": "npm:^20.17.16"
     "@types/react": "npm:^19.0.8"
-    date-fns: "npm:2.16.1"
-    date-fns-tz: "npm:^1.1.6"
-    duration-relativetimeformat: "npm:2.0.4"
+    date-fns: "npm:^4.1.0"
+    duration-relativetimeformat: "npm:^2.0.4"
     i18next: "npm:^21.8.8"
     i18next-browser-languagedetector: "npm:^6.1.4"
     intl-format-cache: "npm:^4.3.1"
@@ -610,6 +610,13 @@ __metadata:
     vitest: "npm:^3.0.5"
   languageName: unknown
   linkType: soft
+
+"@date-fns/tz@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@date-fns/tz@npm:1.2.0"
+  checksum: 10c0/411e9d4303b10951f6fd0189d18fb845f0d934a575df2176bc10daf664282c765fb6b057a977e446bbb1229151d89e7788978600a019f1fc24b5c75276d496bd
+  languageName: node
+  linkType: hard
 
 "@esbuild/aix-ppc64@npm:0.24.2":
   version: 0.24.2
@@ -2672,19 +2679,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns-tz@npm:^1.1.6":
-  version: 1.1.6
-  resolution: "date-fns-tz@npm:1.1.6"
-  peerDependencies:
-    date-fns: ">=2.0.0-alpha.13"
-  checksum: 10c0/8e1f9ed0f1a97d61a49548c42ad54e554236d51d386e5454923b90b51ccfa228bcf7618002682fc0ec40ffc82e66ae97837261b1688f00f31de31201d71ee859
-  languageName: node
-  linkType: hard
-
-"date-fns@npm:2.16.1":
-  version: 2.16.1
-  resolution: "date-fns@npm:2.16.1"
-  checksum: 10c0/6c07ca1b7354e6f1ccea7832a3d0c66ea5fc9c03350307b84779b72094c399816e54a5b3758f1f2383cc27087d787a642fc3b4ed5fc8515225d64d21e4c81f87
+"date-fns@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "date-fns@npm:4.1.0"
+  checksum: 10c0/b79ff32830e6b7faa009590af6ae0fb8c3fd9ffad46d930548fbb5acf473773b4712ae887e156ba91a7b3dc30591ce0f517d69fd83bd9c38650fdc03b4e0bac8
   languageName: node
   linkType: hard
 
@@ -2799,7 +2797,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"duration-relativetimeformat@npm:2.0.4":
+"duration-relativetimeformat@npm:^2.0.4":
   version: 2.0.4
   resolution: "duration-relativetimeformat@npm:2.0.4"
   checksum: 10c0/ca57b0b88c312c1fa77d8758e8fb56940539794d8817e26d2e67b6dbc116504e7c56be1e71e4190e0ca2007bdcba2a80239dbf8d268c773227ec935637a65bbb


### PR DESCRIPTION
- bump date-fns to latest & uses tz support of date-fns
- replace cjs module intl-format-cache with fast-memoize
- bump pretty bytes to latest