### PR TITLE
fix(i18n): use provided value for minimumFractionDigits instead of calculated fallback

### DIFF
--- a/packages/i18n/src/i18n/number/NumberServiceImpl.ts
+++ b/packages/i18n/src/i18n/number/NumberServiceImpl.ts
@@ -122,9 +122,9 @@ export class NumberServiceImpl extends NumberService {
     const minimumFractionDigits =
       options?.minimumFractionDigits ??
       (options?.maximumFractionDigits != null &&
-        fallbackMinimumDigits > options?.maximumFractionDigits)
+      fallbackMinimumDigits > options?.maximumFractionDigits
         ? options?.maximumFractionDigits
-        : fallbackMinimumDigits;
+        : fallbackMinimumDigits);
 
     return {
       ...options,

--- a/packages/i18n/src/i18n/number/NumberServiceImpl.ts
+++ b/packages/i18n/src/i18n/number/NumberServiceImpl.ts
@@ -122,9 +122,9 @@ export class NumberServiceImpl extends NumberService {
     const minimumFractionDigits =
       options?.minimumFractionDigits ??
       (options?.maximumFractionDigits != null &&
-      fallbackMinimumDigits > options?.maximumFractionDigits
+        fallbackMinimumDigits > options?.maximumFractionDigits)
         ? options?.maximumFractionDigits
-        : fallbackMinimumDigits);
+        : fallbackMinimumDigits;
 
     return {
       ...options,

--- a/packages/i18n/test/i18n/number/NumberServiceImpl.test.ts
+++ b/packages/i18n/test/i18n/number/NumberServiceImpl.test.ts
@@ -185,6 +185,15 @@ describe("NumberServiceImpl", () => {
           })
         ).toBe("3.333,330");
       });
+
+      test("minumumFractionDigits regression test", () => {
+        expect(
+          numberService.formatNumber(1.2000000000000002, {
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 3,
+          })
+        ).toBe("1.2");
+      });
     });
 
     describe(".formatPercent()", () => {

--- a/packages/i18n/test/i18n/number/NumberServiceImpl.test.ts
+++ b/packages/i18n/test/i18n/number/NumberServiceImpl.test.ts
@@ -192,7 +192,7 @@ describe("NumberServiceImpl", () => {
             minimumFractionDigits: 0,
             maximumFractionDigits: 3,
           })
-        ).toBe("1.2");
+        ).toBe("1,2");
       });
     });
 


### PR DESCRIPTION
minimumFractionDigits with a value of 0 is ignored due to incorrect parentheses:

`0 ?? (false) ? 3: 16` => 16
`0 ?? ((false) ? 3: 16)` => 0